### PR TITLE
fix: event not visible between 768px and 1199px

### DIFF
--- a/style.css
+++ b/style.css
@@ -262,8 +262,46 @@ h4.upper-h4 {
         font-size: 5rem;
     }
 
-    .card:nth-child(3) {
-        display: none;
+    .cards {
+        width: 70vh;
+        max-height: 80vw;
+        flex-direction: column;
+        justify-content: flex-start;
+        overflow-x: hidden;
+        overflow-y: scroll;
+        transform: rotate(-90deg);
+
+        scrollbar-color: var(--main-color) var(--accent-color);
+        direction: rtl;
+    }
+    .card {
+        transform: rotate(90deg);
+        margin: 5vh;
+        padding: 5vh;
+    }
+
+    .cards::-webkit-scrollbar {
+        width: 1em;
+    }
+    .cards::-webkit-scrollbar-track {
+        background: var(--accent-color);
+        border: 2px solid var(--main-color);
+        border-radius: 0.5em;
+    }
+    .cards::-webkit-scrollbar-thumb {
+        background: var(--main-color);
+        border-radius: 0.5em;
+    }
+
+    .events .cards {
+        scrollbar-color: var(--accent-color) var(--main-color);
+    }
+    .events .cards::-webkit-scrollbar-track {
+        background: var(--main-color);
+        border: 2px solid var(--accent-color);
+    }
+    .events .cards::-webkit-scrollbar-thumb {
+        background: var(--accent-color);
     }
 
     .landing .banner {


### PR DESCRIPTION
resolves #2 

Added horizontal scroll to the cards class on the break-point 768px and 1199px (as suggested), as well as a custom scrollbar in order to clearly represent the usage of the section to the user. 

![scrnli_10_31_2021_8-18-14 PM](https://user-images.githubusercontent.com/52062536/139589457-a7743d58-978d-4839-9058-b20c2ba2dddf.png)

